### PR TITLE
Prepare project for Railway deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies
-RUN --mount=type=cache,target=/root/.npm npm ci --ignore-scripts --omit-dev
+RUN --mount=type=cache,target=/root/.npm npm ci --ignore-scripts
 
 # Copy source code
 COPY . .

--- a/README.md
+++ b/README.md
@@ -287,6 +287,22 @@ curl -H "Authorization: Bearer your-token-here" \
 
 **Note:** Make sure to set either the `NOTION_TOKEN` environment variable (recommended) or the `OPENAPI_MCP_HEADERS` environment variable with your Notion integration token when using either transport mode.
 
+### Deploying to Railway
+
+You can deploy the Notion MCP server to [Railway](https://railway.app/) and expose the HTTP transport for remote clients.
+
+1. Create a new Railway service from this repository or from a GitHub fork.
+2. In the **Variables** tab, set the following values:
+   - `NOTION_TOKEN` – your Notion integration token (or `OPENAPI_MCP_HEADERS` if you prefer custom headers).
+   - `AUTH_TOKEN` – a long, random string that the HTTP transport will require as the bearer token.
+3. Configure the service:
+   - **Build command:** `npm install && npm run build`
+   - **Start command:** `npm start`
+4. Railway automatically provides the `PORT` environment variable. The server detects it, listens on that port, and defaults to the HTTP transport, so no additional configuration is required.
+5. Once deployed, use the health endpoint (`/health`) to verify the service and send MCP requests to the `/mcp` endpoint with the bearer token you configured.
+
+With this setup you can point remote MCP-compatible clients to `https://<your-railway-domain>/mcp` and authenticate requests with the value of `AUTH_TOKEN`.
+
 ### Examples
 
 1. Using the following instruction

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.13.3",
         "axios": "^1.8.4",
+        "esbuild": "^0.25.2",
         "express": "^4.21.2",
         "form-data": "^4.0.1",
         "mustache": "^4.2.0",
@@ -18,6 +19,7 @@
         "openapi-client-axios": "^7.5.5",
         "openapi-schema-validator": "^12.1.3",
         "openapi-types": "^12.1.3",
+        "typescript": "^5.8.2",
         "which": "^5.0.0",
         "yargs": "^17.7.2",
         "zod": "3.24.1"
@@ -34,11 +36,9 @@
         "@types/node": "^20.17.16",
         "@types/which": "^3.0.4",
         "@vitest/coverage-v8": "3.1.1",
-        "esbuild": "^0.25.2",
         "multer": "1.4.5-lts.1",
         "openai": "^4.91.1",
         "tsx": "^4.19.3",
-        "typescript": "^5.8.2",
         "vitest": "^3.1.1"
       }
     },
@@ -167,7 +167,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "aix"
@@ -183,7 +182,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -199,7 +197,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -215,7 +212,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -231,7 +227,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -247,7 +242,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -263,7 +257,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -279,7 +272,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -295,7 +287,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -311,7 +302,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -327,7 +317,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -343,7 +332,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -359,7 +347,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -375,7 +362,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -391,7 +377,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -407,7 +392,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -423,7 +407,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -439,7 +422,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -455,7 +437,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -471,7 +452,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -487,7 +467,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -503,7 +482,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -519,7 +497,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -535,7 +512,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -551,7 +527,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -2124,7 +2099,6 @@
       "version": "0.25.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
       "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
-      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -4008,7 +3982,6 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "type": "module",
   "scripts": {
     "build": "tsc -build && node scripts/build-cli.js",
-    "dev": "tsx watch scripts/start-server.ts"
+    "dev": "tsx watch scripts/start-server.ts",
+    "prestart": "npm run build",
+    "start": "node ./bin/cli.mjs --transport http"
   },
   "bin": {
     "notion-mcp-server": "bin/cli.mjs"
@@ -19,6 +21,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.13.3",
     "axios": "^1.8.4",
+    "esbuild": "^0.25.2",
     "express": "^4.21.2",
     "form-data": "^4.0.1",
     "mustache": "^4.2.0",
@@ -28,7 +31,8 @@
     "openapi-types": "^12.1.3",
     "which": "^5.0.0",
     "yargs": "^17.7.2",
-    "zod": "3.24.1"
+    "zod": "3.24.1",
+    "typescript": "^5.8.2"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.33.1",
@@ -39,11 +43,9 @@
     "@types/node": "^20.17.16",
     "@types/which": "^3.0.4",
     "@vitest/coverage-v8": "3.1.1",
-    "esbuild": "^0.25.2",
     "multer": "1.4.5-lts.1",
     "openai": "^4.91.1",
     "tsx": "^4.19.3",
-    "typescript": "^5.8.2",
     "vitest": "^3.1.1"
   },
   "description": "Official MCP server for Notion API",

--- a/scripts/start-server.ts
+++ b/scripts/start-server.ts
@@ -17,17 +17,64 @@ export async function startServer(args: string[] = process.argv) {
 
   // Parse command line arguments manually (similar to slack-mcp approach)
   function parseArgs() {
-    const args = process.argv.slice(2);
-    let transport = 'stdio'; // default
-    let port = 3000;
-    let authToken: string | undefined;
+    const args = process.argv.slice(2)
+
+    type Transport = 'stdio' | 'http'
+    const isSupportedTransport = (value: string | undefined): value is Transport =>
+      value === 'stdio' || value === 'http'
+
+    const parsePortNumber = (value: string | undefined, source: string): number | undefined => {
+      if (value === undefined) {
+        return undefined
+      }
+
+      const parsed = Number.parseInt(value, 10)
+      if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 65535) {
+        console.warn(`Ignoring ${source} "${value}" because it is not a valid TCP port.`)
+        return undefined
+      }
+
+      return parsed
+    }
+
+    const envPort = parsePortNumber(process.env.PORT, 'PORT environment variable')
+    let port = envPort ?? 3000
+    let portSource: 'env' | 'default' | 'cli' = envPort !== undefined ? 'env' : 'default'
+
+    const envTransportValue = process.env.MCP_TRANSPORT?.toLowerCase()
+    let transport: Transport = 'stdio'
+    let transportSource: 'auto' | 'default' | 'env' | 'cli' = 'default'
+
+    if (isSupportedTransport(envTransportValue)) {
+      transport = envTransportValue
+      transportSource = 'env'
+    } else if (envTransportValue) {
+      console.warn(`Ignoring MCP_TRANSPORT value "${process.env.MCP_TRANSPORT}". Supported transports are 'stdio' or 'http'.`)
+    }
+
+    if (transportSource === 'default' && portSource === 'env') {
+      transport = 'http'
+      transportSource = 'auto'
+    }
+
+    let authToken: string | undefined
 
     for (let i = 0; i < args.length; i++) {
       if (args[i] === '--transport' && i + 1 < args.length) {
-        transport = args[i + 1];
+        const cliTransport = args[i + 1]?.toLowerCase()
+        if (isSupportedTransport(cliTransport)) {
+          transport = cliTransport
+          transportSource = 'cli'
+        } else if (cliTransport) {
+          console.warn(`Ignoring unsupported transport "${args[i + 1]}". Supported transports are 'stdio' or 'http'.`)
+        }
         i++; // skip next argument
       } else if (args[i] === '--port' && i + 1 < args.length) {
-        port = parseInt(args[i + 1], 10);
+        const parsedCliPort = parsePortNumber(args[i + 1], '--port option')
+        if (parsedCliPort !== undefined) {
+          port = parsedCliPort
+          portSource = 'cli'
+        }
         i++; // skip next argument
       } else if (args[i] === '--auth-token' && i + 1 < args.length) {
         authToken = args[i + 1];
@@ -60,7 +107,19 @@ Examples:
       // Ignore unrecognized arguments (like command name passed by Docker)
     }
 
-    return { transport: transport.toLowerCase(), port, authToken };
+    if (transportSource === 'auto') {
+      console.log(`Detected PORT environment variable. Defaulting to HTTP transport.`)
+    }
+
+    if (portSource === 'env') {
+      console.log(`Using port ${port} from PORT environment variable.`)
+    }
+
+    if (transportSource === 'env') {
+      console.log(`Using ${transport} transport from MCP_TRANSPORT environment variable.`)
+    }
+
+    return { transport, port, authToken };
   }
 
   const options = parseArgs()


### PR DESCRIPTION
## Summary
- default the server to HTTP transport when a valid PORT is provided and add validation for transport/port overrides
- add npm start/prestart scripts and move build tooling into dependencies for production installs
- document Railway deployment steps and ensure the Dockerfile installs dev dependencies for the build stage

## Testing
- npm run build
- PORT=4100 AUTH_TOKEN=test npm start

------
https://chatgpt.com/codex/tasks/task_e_68ca323c78148322aa18b82cac2f8957